### PR TITLE
Add comp system: billing_type, comp ability, safety rails

### DIFF
--- a/inc/abilities/class-abilities.php
+++ b/inc/abilities/class-abilities.php
@@ -118,6 +118,67 @@ class Abilities {
 			'permission_callback' => array( __CLASS__, 'check_admin_permission' ),
 		) );
 
+		// Comp Customer (create free customer)
+		wp_register_ability( 'spawn/comp-customer', array(
+			'label'               => __( 'Comp Customer', 'spawn' ),
+			'description'         => __( 'Create a comped (free) customer with VPS but no Stripe subscription. Admin use only.', 'spawn' ),
+			'category'            => 'spawn',
+			'execute_callback'    => array( Ability_Comp_Customer::class, 'execute' ),
+			'input_schema'        => array(
+				'type'       => 'object',
+				'required'   => array( 'email' ),
+				'properties' => array(
+					'email'           => array(
+						'type'        => 'string',
+						'format'      => 'email',
+						'description' => 'Customer email address',
+					),
+					'tier'            => array(
+						'type'        => 'string',
+						'enum'        => \Spawn\Config::get_tier_ids(),
+						'default'     => 'starter',
+						'description' => 'Tier (starter, pro, business)',
+					),
+					'wants_website'  => array(
+						'type'        => 'boolean',
+						'default'     => true,
+						'description' => 'Whether customer wants a website',
+					),
+					'domain'         => array(
+						'type'        => 'string',
+						'description' => 'Optional domain for the customer',
+					),
+					'domain_type'    => array(
+						'type'        => 'string',
+						'enum'        => array( 'subdomain', 'register', 'byod' ),
+						'default'     => 'subdomain',
+						'description' => 'Domain type: subdomain, register, or byod',
+					),
+					'customer_region' => array(
+						'type'        => 'string',
+						'enum'        => array( 'us', 'eu' ),
+						'default'     => 'us',
+						'description' => 'Customer region (us or eu)',
+					),
+				),
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'success'              => array( 'type' => 'boolean' ),
+					'customer_id'          => array( 'type' => 'integer' ),
+					'email'               => array( 'type' => 'string' ),
+					'tier'                => array( 'type' => 'string' ),
+					'billing_type'       => array( 'type' => 'string' ),
+					'status'              => array( 'type' => 'string' ),
+					'domain'              => array( 'type' => 'string' ),
+					'domain_type'        => array( 'type' => 'string' ),
+					'provisioning_job_id' => array( 'type' => 'string' ),
+				),
+			),
+			'permission_callback' => array( __CLASS__, 'check_admin_permission' ),
+		) );
+
 		// Get Usage
 		wp_register_ability( 'spawn/get-usage', array(
 			'label'               => __( 'Get Usage', 'spawn' ),

--- a/inc/abilities/class-ability-comp-customer.php
+++ b/inc/abilities/class-ability-comp-customer.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * Comp Customer ability.
+ *
+ * Creates a comped (free) customer with VPS but no Stripe subscription.
+ *
+ * @package Spawn
+ */
+
+namespace Spawn\Abilities;
+
+use Spawn\Config;
+use Spawn\Database;
+use Spawn\Provisioner;
+use WP_Error;
+
+/**
+ * Creates a comped customer - free VPS without Stripe payment.
+ */
+class Ability_Comp_Customer {
+
+	/**
+	 * Execute the ability.
+	 *
+	 * @param array $input Input parameters.
+	 * @return array|WP_Error Result or error.
+	 */
+	public static function execute( array $input ): array|\WP_Error {
+		$email        = \sanitize_email( $input['email'] ?? '' );
+		$tier         = \sanitize_text_field( $input['tier'] ?? 'starter' );
+		$wants_website = isset( $input['wants_website'] ) ? (bool) $input['wants_website'] : true;
+		$domain       = ! empty( $input['domain'] ) ? \sanitize_text_field( $input['domain'] ) : '';
+		$domain_type  = \sanitize_text_field( $input['domain_type'] ?? 'subdomain' );
+
+		if ( empty( $email ) ) {
+			return new \WP_Error( 'missing_email', \__( 'Email is required', 'spawn' ) );
+		}
+
+		if ( ! \is_email( $email ) ) {
+			return new \WP_Error( 'invalid_email', \__( 'Invalid email address', 'spawn' ) );
+		}
+
+		if ( ! in_array( $tier, Config::get_tier_ids(), true ) ) {
+			return new \WP_Error( 'invalid_tier', \__( 'Invalid tier. Must be starter, pro, or business', 'spawn' ) );
+		}
+
+		$valid_domain_types = array( 'subdomain', 'register', 'byod' );
+		if ( ! in_array( $domain_type, $valid_domain_types, true ) ) {
+			return new \WP_Error( 'invalid_domain_type', \__( 'Invalid domain type. Must be subdomain, register, or byod', 'spawn' ) );
+		}
+
+		$existing_customer = Database::get_customer_by_email( $email );
+		if ( $existing_customer ) {
+			return new \WP_Error(
+				'customer_exists',
+				\sprintf(
+					\__( 'Customer with email %s already exists', 'spawn' ),
+					$email
+				)
+			);
+		}
+
+		if ( ! empty( $domain ) ) {
+			$existing_domain = Database::get_customer_by_domain( $domain );
+			if ( $existing_domain ) {
+				return new \WP_Error(
+					'domain_exists',
+					\sprintf(
+						\__( 'Domain %s already exists', 'spawn' ),
+						$domain
+					)
+				);
+			}
+		}
+
+		$user_id = self::get_or_create_user( $email );
+		if ( \is_wp_error( $user_id ) ) {
+			return $user_id;
+		}
+
+		$customer_id = Database::create_customer( array(
+			'user_id'         => $user_id,
+			'email'           => $email,
+			'domain'          => $domain ?: null,
+			'domain_type'     => $domain_type,
+			'tier'            => $tier,
+			'wants_website'  => $wants_website,
+			'billing_type'    => 'comped',
+			'status'          => 'provisioning',
+			'customer_region' => $input['customer_region'] ?? 'us',
+		) );
+
+		if ( ! $customer_id ) {
+			return new \WP_Error( 'creation_failed', \__( 'Failed to create customer record', 'spawn' ) );
+		}
+
+		$is_subdomain = 'subdomain' === $domain_type;
+
+		$result = Provisioner::trigger( array(
+			'customer_id'    => $customer_id,
+			'customer_email' => $email,
+			'domain'         => $domain,
+			'domain_type'    => $domain_type,
+			'tier'           => $tier,
+			'wants_website'  => $wants_website,
+			'subdomain'      => $is_subdomain,
+		) );
+
+		if ( \is_wp_error( $result ) ) {
+			Database::update_customer( $customer_id, array( 'status' => 'failed' ) );
+			return new \WP_Error(
+				'provisioning_failed',
+				$result->get_error_message()
+			);
+		}
+
+		return array(
+			'success'              => true,
+			'customer_id'          => $customer_id,
+			'email'                => $email,
+			'tier'                 => $tier,
+			'billing_type'        => 'comped',
+			'status'               => 'provisioning',
+			'domain'               => $domain ?: null,
+			'domain_type'         => $domain_type,
+			'provisioning_job_id' => $result['job_id'] ?? null,
+		);
+	}
+
+	/**
+	 * Get existing user or create new one.
+	 *
+	 * @param string $email User email.
+	 * @return int|\WP_Error User ID or error.
+	 */
+	private static function get_or_create_user( string $email ): int|\WP_Error {
+		$user = \get_user_by( 'email', $email );
+
+		if ( $user ) {
+			return $user->ID;
+		}
+
+		$username = self::generate_username( $email );
+		$password = \wp_generate_password( 12, true );
+
+		$user_id = \wp_create_user( $username, $password, $email );
+
+		if ( \is_wp_error( $user_id ) ) {
+			return new \WP_Error(
+				'user_creation_failed',
+				$user_id->get_error_message()
+			);
+		}
+
+		\wp_new_user_notification( $user_id, null, 'both' );
+
+		return $user_id;
+	}
+
+	/**
+	 * Generate a unique username from email.
+	 *
+	 * @param string $email User email.
+	 * @return string Unique username.
+	 */
+	private static function generate_username( string $email ): string {
+		$username = \sanitize_user( explode( '@', $email )[0], true );
+		$username = str_replace( array( '-', '_' ), '', $username );
+
+		if ( \username_exists( $username ) ) {
+			$suffix = 1;
+			while ( \username_exists( $username . $suffix ) ) {
+				++$suffix;
+			}
+			$username .= $suffix;
+		}
+
+		return $username;
+	}
+}

--- a/inc/class-cleanup.php
+++ b/inc/class-cleanup.php
@@ -55,6 +55,12 @@ class Cleanup {
 	 * @return bool Success.
 	 */
 	public static function delete_customer_resources( array $customer ): bool {
+		// Skip comped customers - they don't have subscriptions to trigger deletions.
+		if ( 'comped' === ( $customer['billing_type'] ?? 'paid' ) ) {
+			error_log( sprintf( '[Spawn Cleanup] Skipping comped customer #%d (%s) - comped customers are not auto-deleted', $customer['id'], $customer['domain'] ) );
+			return true;
+		}
+
 		$customer_id = (int) $customer['id'];
 		$success     = true;
 

--- a/inc/class-config.php
+++ b/inc/class-config.php
@@ -334,4 +334,28 @@ class Config {
 			'margin_pct'   => round( ( $margin / $tier['price'] ) * 100, 1 ),
 		);
 	}
+
+	/**
+	 * Get all billing types.
+	 *
+	 * @return array Billing types keyed by type ID.
+	 */
+	public static function get_billing_types(): array {
+		$types = array(
+			'paid'   => __( 'Paid', 'spawn' ),
+			'comped' => __( 'Comped', 'spawn' ),
+		);
+		return apply_filters( 'spawn_billing_types', $types );
+	}
+
+	/**
+	 * Get a single billing type label.
+	 *
+	 * @param string $billing_type Billing type ID.
+	 * @return string Billing type label or the type ID if not found.
+	 */
+	public static function get_billing_type_label( string $billing_type ): string {
+		$types = self::get_billing_types();
+		return $types[ $billing_type ] ?? $billing_type;
+	}
 }

--- a/inc/class-database.php
+++ b/inc/class-database.php
@@ -71,6 +71,7 @@ class Database {
 			domain_price decimal(10,2) DEFAULT NULL,
 			domain_expires_at datetime DEFAULT NULL,
 			tier varchar(50) NOT NULL DEFAULT 'starter',
+			billing_type varchar(20) NOT NULL DEFAULT 'paid',
 			billing_mode varchar(20) NOT NULL DEFAULT 'managed',
 			wants_website tinyint(1) NOT NULL DEFAULT 1,
 			server_type varchar(50) NOT NULL DEFAULT 'cpx21',
@@ -102,7 +103,8 @@ class Database {
 			KEY stripe_subscription (stripe_subscription),
 			KEY status (status),
 			KEY domain_expires_at (domain_expires_at),
-			KEY tier (tier)
+			KEY tier (tier),
+			KEY billing_type (billing_type)
 		) {$charset_collate};";
 
 		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
@@ -223,6 +225,23 @@ class Database {
 	}
 
 	/**
+	 * Add billing_type column for comp system.
+	 *
+	 * Adds the billing_type column to existing installations.
+	 * Default is 'paid' for existing customers.
+	 */
+	public static function migrate_add_billing_type(): void {
+		global $wpdb;
+
+		$table   = self::get_table_name();
+		$columns = $wpdb->get_col( "SHOW COLUMNS FROM {$table}" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery
+		if ( ! in_array( 'billing_type', $columns, true ) ) {
+			$wpdb->query( "ALTER TABLE {$table} ADD COLUMN billing_type varchar(20) NOT NULL DEFAULT 'paid' AFTER tier" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery
+			$wpdb->query( "ALTER TABLE {$table} ADD KEY billing_type (billing_type)" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery
+		}
+	}
+
+	/**
 	 * Create usage table for per-server usage tracking.
 	 */
 	public static function create_usage_table(): void {
@@ -299,6 +318,7 @@ class Database {
 				'domain_price'        => $data['domain_price'] ?? null,
 				'domain_expires_at'   => $domain_expires,
 				'tier'                => $tier,
+				'billing_type'        => $data['billing_type'] ?? 'paid',
 				'wants_website'       => $wants_website ? 1 : 0,
 				'server_type'        => $server_config['server_type'],
 				'server_location'    => $server_config['location'],
@@ -309,7 +329,7 @@ class Database {
 				'customer_region'     => $customer_region,
 				'created_at'          => current_time( 'mysql' ),
 			),
-			array( '%d', '%s', '%s', '%d', '%s', '%f', '%s', '%s', '%d', '%s', '%s', '%s', '%s', '%s', '%f', '%s', '%s' )
+			array( '%d', '%s', '%s', '%d', '%s', '%f', '%s', '%s', '%s', '%d', '%s', '%s', '%s', '%s', '%s', '%f', '%s', '%s' )
 		);
 
 		return $result ? $wpdb->insert_id : false;

--- a/inc/class-webhook.php
+++ b/inc/class-webhook.php
@@ -430,6 +430,11 @@ class Webhook {
 			return;
 		}
 
+		// Skip for comped customers - they don't have subscriptions.
+		if ( 'comped' === ( $customer['billing_type'] ?? 'paid' ) ) {
+			return;
+		}
+
 		// Mark subscription as active and update renewal date.
 		// No monthly credits — AI credits are pay-as-you-go.
 		Database::update_customer( $customer['id'], array(
@@ -460,6 +465,11 @@ class Webhook {
 
 		$customer = Database::get_customer_by_subscription( $subscription_id );
 		if ( $customer ) {
+			// Skip for comped customers - they don't have subscriptions.
+			if ( 'comped' === ( $customer['billing_type'] ?? 'paid' ) ) {
+				return;
+			}
+
 			Database::update_customer( $customer['id'], array(
 				'status' => 'payment_failed',
 			) );
@@ -485,6 +495,11 @@ class Webhook {
 
 		$customer = Database::get_customer_by_subscription( $subscription_id );
 		if ( ! $customer ) {
+			return;
+		}
+
+		// Skip for comped customers - they don't have subscriptions to cancel.
+		if ( 'comped' === ( $customer['billing_type'] ?? 'paid' ) ) {
 			return;
 		}
 

--- a/spawn.php
+++ b/spawn.php
@@ -117,6 +117,7 @@ function activate(): void {
 	// Run column migrations for existing installations.
 	Database::migrate_column_names();
 	Database::migrate_remove_api_key_column();
+	Database::migrate_add_billing_type();
 
 	// Register user role.
 	User_Role::register_role();


### PR DESCRIPTION
## What

Adds the ability to comp a VPS to someone without requiring Stripe payment. Comped customers get a full Spawn account and VPS but don't pay the monthly subscription. They still need to buy AI credits or BYOK when they want to use their agent.

## Changes

### New: `billing_type` field (filter-extensible)
- Added `billing_type` column to `spawn_customers` table (default: `paid`)
- `Config::get_billing_types()` with `spawn_billing_types` filter for extensibility
- Migration method for existing installations

### New: `spawn_comp_customer` ability
- Takes: email, tier, wants_website, domain, domain_type
- Creates WP user account (sends new-user email with login credentials)
- Creates customer record with `billing_type = 'comped'`, no Stripe fields
- Triggers provisioning via same path as paid customers
- Validates: email format, tier, domain uniqueness, existing customers

### Safety rails for comped customers
- `handle_invoice_paid` — skips comped customers (no subscription to renew)
- `handle_payment_failed` — skips comped customers
- `handle_subscription_cancelled` — skips comped customers (no subscription to cancel)
- `Cleanup` — skips comped customers during payment-based deletion

### Stripe is deferred
Comped customers get NO Stripe customer/subscription at creation. Stripe customer is created later when/if they buy credits.

## Architecture decisions
- Filter-based extensibility (`spawn_billing_types` filter)
- Abilities as the primitive (Star Fleet Command or admin tools invoke it)
- Stripe deferred until credit purchase