### PR TITLE
Add chat storefront blocks: auth-gate, credit-balance, credit-purchase

### DIFF
--- a/blocks/auth-gate/block.json
+++ b/blocks/auth-gate/block.json
@@ -1,0 +1,21 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "spawn/auth-gate",
+	"version": "1.0.0",
+	"title": "Auth Gate",
+	"category": "spawn",
+	"icon": "lock",
+	"description": "Shows login UI when user is not authenticated, renders inner content when authenticated.",
+	"parent": ["spawn/chat"],
+	"usesContext": ["spawn/isAuthenticated"],
+	"supports": {
+		"html": false
+	},
+	"textdomain": "spawn",
+	"editorScript": "file:./index.js",
+	"editorStyle": "file:./index.css",
+	"style": "file:./style.css",
+	"render": "file:./render.php",
+	"viewScript": "file:./view.js"
+}

--- a/blocks/auth-gate/index.js
+++ b/blocks/auth-gate/index.js
@@ -1,0 +1,19 @@
+import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
+
+export default function Edit() {
+	const blockProps = useBlockProps({
+		className: 'wp-block-spawn-auth-gate__editor',
+	});
+
+	return (
+		<div { ...blockProps }>
+			<div className="wp-block-spawn-auth-gate__editor-label">
+				<span className="dashicon dashicons-lock"></span>
+				Auth Gate (Content shown only when logged in)
+			</div>
+			<div className="wp-block-spawn-auth-gate__editor-content">
+				<InnerBlocks />
+			</div>
+		</div>
+	);
+}

--- a/blocks/auth-gate/render.php
+++ b/blocks/auth-gate/render.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Auth Gate block render template.
+ *
+ * @var array    $attributes Block attributes.
+ * @var string   $content    Block default content.
+ * @var WP_Block $block      Block instance.
+ *
+ * @package Spawn
+ */
+
+use Spawn\Branding;
+
+$wrapper_attributes = get_block_wrapper_attributes( array(
+	'class' => 'wp-block-spawn-auth-gate',
+) );
+
+$is_authenticated = $block->context['spawn/isAuthenticated'] ?? is_user_logged_in();
+
+if ( $is_authenticated ) {
+	?>
+	<div <?php echo $wrapper_attributes; ?>>
+		<?php echo $content; ?>
+	</div>
+	<?php
+	return;
+}
+
+$brand_name     = Branding::get_brand_name();
+$brand_logo_url = Branding::get_brand_logo_url();
+?>
+<div <?php echo $wrapper_attributes; ?>>
+	<div class="wp-block-spawn-auth-gate__login">
+		<div class="wp-block-spawn-auth-gate__login-header">
+			<?php if ( '' !== $brand_logo_url ) : ?>
+				<img src="<?php echo esc_url( $brand_logo_url ); ?>" alt="<?php echo esc_attr( $brand_name ); ?>" width="48" height="48" />
+			<?php endif; ?>
+			<h2><?php echo esc_html__( 'Welcome', 'spawn' ); ?></h2>
+			<p><?php echo esc_html__( 'Log in to access your AI assistant', 'spawn' ); ?></p>
+		</div>
+		<form class="wp-block-spawn-auth-gate__form" method="post" action="<?php echo esc_url( wp_login_url() ); ?>">
+			<input type="hidden" name="redirect_to" value="<?php echo esc_attr( home_url( '/spawn/chat/' ) ); ?>" />
+			<div class="wp-block-spawn-auth-gate__field">
+				<label for="user_login"><?php esc_html_e( 'Email', 'spawn' ); ?></label>
+				<input type="text" name="log" id="user_login" class="input" required />
+			</div>
+			<div class="wp-block-spawn-auth-gate__field">
+				<label for="user_pass"><?php esc_html_e( 'Password', 'spawn' ); ?></label>
+				<input type="password" name="pwd" id="user_pass" class="input" required />
+			</div>
+			<div class="wp-block-spawn-auth-gate__actions">
+				<button type="submit" class="wp-block-spawn-auth-gate__submit">
+					<?php esc_html_e( 'Log In', 'spawn' ); ?>
+				</button>
+			</div>
+		</form>
+		<div class="wp-block-spawn-auth-gate__links">
+			<a href="<?php echo esc_url( wp_registration_url() ); ?>"><?php esc_html_e( 'Create an account', 'spawn' ); ?></a>
+			<span class="wp-block-spawn-auth-gate__separator">|</span>
+			<a href="<?php echo esc_url( wp_lostpassword_url() ); ?>"><?php esc_html_e( 'Forgot password?', 'spawn' ); ?></a>
+		</div>
+	</div>
+</div>

--- a/blocks/auth-gate/style.css
+++ b/blocks/auth-gate/style.css
@@ -1,0 +1,130 @@
+.wp-block-spawn-auth-gate {
+	display: block;
+}
+
+.wp-block-spawn-auth-gate__login {
+	max-width: 320px;
+	margin: 0 auto;
+	padding: 24px;
+	text-align: center;
+}
+
+.wp-block-spawn-auth-gate__login-header {
+	margin-bottom: 24px;
+}
+
+.wp-block-spawn-auth-gate__login-header img {
+	margin-bottom: 12px;
+}
+
+.wp-block-spawn-auth-gate__login-header h2 {
+	margin: 0 0 8px;
+	font-size: 24px;
+	font-weight: 600;
+}
+
+.wp-block-spawn-auth-gate__login-header p {
+	margin: 0;
+	color: #666;
+	font-size: 14px;
+}
+
+.wp-block-spawn-auth-gate__form {
+	text-align: left;
+}
+
+.wp-block-spawn-auth-gate__field {
+	margin-bottom: 16px;
+}
+
+.wp-block-spawn-auth-gate__field label {
+	display: block;
+	margin-bottom: 4px;
+	font-size: 14px;
+	font-weight: 500;
+}
+
+.wp-block-spawn-auth-gate__field input {
+	width: 100%;
+	padding: 10px 12px;
+	font-size: 14px;
+	border: 1px solid #ddd;
+	border-radius: 4px;
+	box-sizing: border-box;
+}
+
+.wp-block-spawn-auth-gate__field input:focus {
+	outline: none;
+	border-color: #2271b1;
+	box-shadow: 0 0 0 2px rgba(34, 113, 177, 0.2);
+}
+
+.wp-block-spawn-auth-gate__actions {
+	margin-top: 20px;
+}
+
+.wp-block-spawn-auth-gate__submit {
+	width: 100%;
+	padding: 12px;
+	font-size: 14px;
+	font-weight: 600;
+	color: #fff;
+	background: #2271b1;
+	border: none;
+	border-radius: 4px;
+	cursor: pointer;
+	transition: background 0.2s;
+}
+
+.wp-block-spawn-auth-gate__submit:hover {
+	background: #1a5a8a;
+}
+
+.wp-block-spawn-auth-gate__links {
+	margin-top: 16px;
+	font-size: 13px;
+}
+
+.wp-block-spawn-auth-gate__links a {
+	color: #2271b1;
+	text-decoration: none;
+}
+
+.wp-block-spawn-auth-gate__links a:hover {
+	text-decoration: underline;
+}
+
+.wp-block-spawn-auth-gate__separator {
+	margin: 0 8px;
+	color: #ccc;
+}
+
+.wp-block-spawn-auth-gate__editor {
+	border: 2px dashed #ddd;
+	padding: 16px;
+	background: #f9f9f9;
+}
+
+.wp-block-spawn-auth-gate__editor-label {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin-bottom: 12px;
+	padding: 8px 12px;
+	background: #fff;
+	border: 1px solid #ddd;
+	border-radius: 4px;
+	font-size: 13px;
+	color: #555;
+}
+
+.wp-block-spawn-auth-gate__editor-label .dashicon {
+	color: #666;
+}
+
+.wp-block-spawn-auth-gate__editor-content {
+	padding: 12px;
+	background: #fff;
+	border: 1px solid #eee;
+	border-radius: 4px;
+}

--- a/blocks/auth-gate/view.js
+++ b/blocks/auth-gate/view.js
@@ -1,0 +1,36 @@
+/**
+ * Auth Gate block view script.
+ */
+( function () {
+	'use strict';
+
+	const containers = document.querySelectorAll( '.wp-block-spawn-auth-gate' );
+
+	containers.forEach( function ( container ) {
+		const form = container.querySelector( '.wp-block-spawn-auth-gate__form' );
+		if ( ! form ) {
+			return;
+		}
+
+		form.addEventListener( 'submit', function ( e ) {
+			const redirectTo = form.querySelector( 'input[name="redirect_to"]' );
+			if ( redirectTo && redirectTo.value ) {
+				sessionStorage.setItem( 'spawn_auth_redirect', redirectTo.value );
+			}
+		} );
+	} );
+
+	const handleAuthChange = () => {
+		const isLoggedIn = document.body.classList.contains( 'logged-in' ) ||
+			document.querySelector( '.wp-block-spawn-chat[data-context]' );
+
+		if ( isLoggedIn ) {
+			window.location.reload();
+		}
+	};
+
+	const urlParams = new URLSearchParams( window.location.search );
+	if ( urlParams.get( 'loggedout' ) === 'true' ) {
+		handleAuthChange();
+	}
+} )();

--- a/blocks/chat/block.json
+++ b/blocks/chat/block.json
@@ -21,6 +21,16 @@
 			"default": ""
 		}
 	},
+	"providesContext": {
+		"spawn/isAuthenticated": "isAuthenticated",
+		"spawn/customerId": "customerId",
+		"spawn/billingMode": "billingMode"
+	},
+	"allowedBlocks": [
+		"spawn/auth-gate",
+		"spawn/credit-balance",
+		"spawn/credit-purchase"
+	],
 	"textdomain": "spawn",
 	"editorScript": "file:./index.js",
 	"editorStyle": "file:./index.css",

--- a/blocks/chat/index.js
+++ b/blocks/chat/index.js
@@ -1,0 +1,47 @@
+import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
+
+const TEMPLATE = [
+	[
+		'spawn/auth-gate',
+		{},
+		[
+			[
+				'core/group',
+				{},
+				[
+					[
+						'spawn/credit-balance',
+						{},
+					],
+					[
+						'spawn/credit-purchase',
+						{},
+					],
+				],
+			],
+		],
+	],
+];
+
+export default function Edit() {
+	const blockProps = useBlockProps({
+		className: 'wp-block-spawn-chat__editor',
+	});
+
+	return (
+		<div { ...blockProps }>
+			<div className="wp-block-spawn-chat__editor-header">
+				<span className="wp-block-spawn-chat__editor-label">Spawn Chat</span>
+			</div>
+			<InnerBlocks
+				allowedBlocks={ [
+					'spawn/auth-gate',
+					'spawn/credit-balance',
+					'spawn/credit-purchase',
+				] }
+				template={ TEMPLATE }
+				templateLock={ false }
+			/>
+		</div>
+	);
+}

--- a/blocks/chat/render.php
+++ b/blocks/chat/render.php
@@ -25,6 +25,27 @@ $wrapper_attributes = get_block_wrapper_attributes( array(
 $brand_name     = Branding::get_brand_name();
 $brand_logo_url = Branding::get_brand_logo_url();
 
+// Determine auth state and customer data.
+$is_authenticated = is_user_logged_in();
+$customer_id     = 0;
+$billing_mode   = 'managed';
+
+if ( $is_authenticated ) {
+	$user_id  = get_current_user_id();
+	$customer = \Spawn\Database::get_customer_by_user_id( $user_id );
+	$is_admin = current_user_can( 'manage_options' );
+
+	if ( $customer || $is_admin ) {
+		$customer_id   = $customer['id'] ?? 0;
+		$billing_mode  = $customer['billing_mode'] ?? 'managed';
+	}
+}
+
+// Set block context.
+$block->context['spawn/isAuthenticated'] = $is_authenticated;
+$block->context['spawn/customerId']     = $customer_id;
+$block->context['spawn/billingMode']    = $billing_mode;
+
 // Check if user is logged in.
 if ( ! is_user_logged_in() ) {
 	?>
@@ -123,6 +144,13 @@ if ( $is_admin && ! $customer ) {
 			<a href="<?php echo esc_url( wp_logout_url( home_url( '/spawn/' ) ) ); ?>">Log out</a>
 		</nav>
 	</div>
+
+	<!-- Inner blocks area -->
+	<?php if ( ! empty( $content ) ) : ?>
+		<div class="wp-block-spawn-chat__inner-blocks">
+			<?php echo $content; ?>
+		</div>
+	<?php endif; ?>
 
 	<div class="wp-block-spawn-chat__layout">
 		<!-- Sidebar with session list -->

--- a/blocks/credit-balance/block.json
+++ b/blocks/credit-balance/block.json
@@ -1,0 +1,20 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "spawn/credit-balance",
+	"version": "1.0.0",
+	"title": "Credit Balance",
+	"category": "spawn",
+	"icon": "cart",
+	"description": "Displays the customer's current AI credit balance.",
+	"usesContext": ["spawn/customerId"],
+	"supports": {
+		"html": false
+	},
+	"textdomain": "spawn",
+	"editorScript": "file:./index.js",
+	"editorStyle": "file:./index.css",
+	"style": "file:./style.css",
+	"render": "file:./render.php",
+	"viewScript": "file:./view.js"
+}

--- a/blocks/credit-balance/index.js
+++ b/blocks/credit-balance/index.js
@@ -1,0 +1,21 @@
+import { useBlockProps } from '@wordpress/block-editor';
+
+export default function Edit() {
+	const blockProps = useBlockProps({
+		className: 'wp-block-spawn-credit-balance__editor',
+	});
+
+	return (
+		<div { ...blockProps }>
+			<div className="wp-block-spawn-credit-balance__editor-placeholder">
+				<span className="wp-block-spawn-credit-balance__editor-icon">
+					<span className="dashicon dashicons-cart"></span>
+				</span>
+				<div className="wp-block-spawn-credit-balance__editor-info">
+					<span className="wp-block-spawn-credit-balance__editor-label">Credit Balance</span>
+					<span className="wp-block-spawn-credit-balance__editor-value">$0.00</span>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/blocks/credit-balance/render.php
+++ b/blocks/credit-balance/render.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Credit Balance block render template.
+ *
+ * @var array    $attributes Block attributes.
+ * @var string   $content    Block default content.
+ * @var WP_Block $block      Block instance.
+ *
+ * @package Spawn
+ */
+
+$wrapper_attributes = get_block_wrapper_attributes( array(
+	'class' => 'wp-block-spawn-credit-balance',
+) );
+
+$customer_id = $block->context['spawn/customerId'] ?? 0;
+
+if ( ! $customer_id ) {
+	return;
+}
+
+$credit_balance = \Spawn\Database::get_credit_balance( $customer_id );
+?>
+<div <?php echo $wrapper_attributes; ?>>
+	<div class="wp-block-spawn-credit-balance__display">
+		<span class="wp-block-spawn-credit-balance__label">
+			<?php esc_html_e( 'Balance', 'spawn' ); ?>
+		</span>
+		<span class="wp-block-spawn-credit-balance__amount" data-balance="<?php echo esc_attr( $credit_balance ); ?>">
+			$<?php echo esc_html( number_format( $credit_balance, 2 ) ); ?>
+		</span>
+	</div>
+</div>

--- a/blocks/credit-balance/style.css
+++ b/blocks/credit-balance/style.css
@@ -1,0 +1,73 @@
+.wp-block-spawn-credit-balance {
+	display: block;
+}
+
+.wp-block-spawn-credit-balance__display {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	padding: 12px 16px;
+	background: #f0f6f9;
+	border-radius: 8px;
+}
+
+.wp-block-spawn-credit-balance__label {
+	font-size: 12px;
+	font-weight: 500;
+	color: #666;
+	text-transform: uppercase;
+	letter-spacing: 0.5px;
+}
+
+.wp-block-spawn-credit-balance__amount {
+	font-size: 24px;
+	font-weight: 700;
+	color: #2271b1;
+}
+
+.wp-block-spawn-credit-balance__editor {
+	padding: 16px;
+	background: #f9f9f9;
+	border: 1px solid #ddd;
+	border-radius: 4px;
+}
+
+.wp-block-spawn-credit-balance__editor-placeholder {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	padding: 12px;
+	background: #f0f6f9;
+	border-radius: 8px;
+}
+
+.wp-block-spawn-credit-balance__editor-icon {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 40px;
+	height: 40px;
+	background: #fff;
+	border-radius: 8px;
+	color: #666;
+}
+
+.wp-block-spawn-credit-balance__editor-info {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+}
+
+.wp-block-spawn-credit-balance__editor-label {
+	font-size: 11px;
+	font-weight: 500;
+	color: #666;
+	text-transform: uppercase;
+	letter-spacing: 0.5px;
+}
+
+.wp-block-spawn-credit-balance__editor-value {
+	font-size: 20px;
+	font-weight: 700;
+	color: #999;
+}

--- a/blocks/credit-balance/view.js
+++ b/blocks/credit-balance/view.js
@@ -1,0 +1,79 @@
+/**
+ * Credit Balance block view script.
+ */
+( function () {
+	'use strict';
+
+	const API_ROOT = '/wp-json/spawn/v1';
+	const POLL_INTERVAL = 30000;
+
+	let pollTimer = null;
+
+	async function fetchBalance() {
+		try {
+			const response = await fetch( `${ API_ROOT }/credits/balance`, {
+				credentials: 'include',
+			} );
+
+			if ( ! response.ok ) {
+				return;
+			}
+
+			const data = await response.json();
+			updateBalanceDisplay( data.balance );
+		} catch ( error ) {
+			console.error( 'Failed to fetch balance:', error );
+		}
+	}
+
+	function updateBalanceDisplay( balance ) {
+		const containers = document.querySelectorAll( '.wp-block-spawn-credit-balance' );
+
+		containers.forEach( function ( container ) {
+			const amountEl = container.querySelector( '.wp-block-spawn-credit-balance__amount' );
+			if ( amountEl ) {
+				amountEl.textContent = `$${ balance.toFixed( 2 ) }`;
+				amountEl.dataset.balance = balance;
+			}
+		} );
+	}
+
+	function startPolling() {
+		if ( pollTimer ) {
+			return;
+		}
+
+		fetchBalance();
+		pollTimer = setInterval( fetchBalance, POLL_INTERVAL );
+	}
+
+	function stopPolling() {
+		if ( pollTimer ) {
+			clearInterval( pollTimer );
+			pollTimer = null;
+		}
+	}
+
+	document.addEventListener( 'DOMContentLoaded', function () {
+		const containers = document.querySelectorAll( '.wp-block-spawn-credit-balance' );
+
+		if ( containers.length > 0 ) {
+			startPolling();
+		}
+	} );
+
+	document.addEventListener( 'visibilitychange', function () {
+		if ( document.hidden ) {
+			stopPolling();
+		} else {
+			const containers = document.querySelectorAll( '.wp-block-spawn-credit-balance' );
+			if ( containers.length > 0 ) {
+				startPolling();
+			}
+		}
+	} );
+
+	window.addEventListener( 'spawn-credit-purchased', function () {
+		fetchBalance();
+	} );
+} )();

--- a/blocks/credit-purchase/block.json
+++ b/blocks/credit-purchase/block.json
@@ -1,0 +1,20 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "spawn/credit-purchase",
+	"version": "1.0.0",
+	"title": "Credit Purchase",
+	"category": "spawn",
+	"icon": "money",
+	"description": "Inline credit purchasing with Stripe.",
+	"usesContext": ["spawn/customerId"],
+	"supports": {
+		"html": false
+	},
+	"textdomain": "spawn",
+	"editorScript": "file:./index.js",
+	"editorStyle": "file:./index.css",
+	"style": "file:./style.css",
+	"render": "file:./render.php",
+	"viewScript": "file:./view.js"
+}

--- a/blocks/credit-purchase/index.js
+++ b/blocks/credit-purchase/index.js
@@ -1,0 +1,20 @@
+import { useBlockProps } from '@wordpress/block-editor';
+
+export default function Edit() {
+	const blockProps = useBlockProps({
+		className: 'wp-block-spawn-credit-purchase__editor',
+	});
+
+	return (
+		<div { ...blockProps }>
+			<div className="wp-block-spawn-credit-purchase__editor-placeholder">
+				<div className="wp-block-spawn-credit-purchase__editor-label">Credit Purchase</div>
+				<div className="wp-block-spawn-credit-purchase__editor-buttons">
+					<button className="wp-block-spawn-credit-purchase__editor-btn" type="button">$10</button>
+					<button className="wp-block-spawn-credit-purchase__editor-btn" type="button">$25</button>
+					<button className="wp-block-spawn-credit-purchase__editor-btn" type="button">$50</button>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/blocks/credit-purchase/render.php
+++ b/blocks/credit-purchase/render.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Credit Purchase block render template.
+ *
+ * @var array    $attributes Block attributes.
+ * @var string   $content    Block default content.
+ * @var WP_Block $block      Block instance.
+ *
+ * @package Spawn
+ */
+
+use Spawn\Controllers\Credits_Controller;
+
+$wrapper_attributes = get_block_wrapper_attributes( array(
+	'class' => 'wp-block-spawn-credit-purchase',
+) );
+
+$customer_id = $block->context['spawn/customerId'] ?? 0;
+
+if ( ! $customer_id ) {
+	return;
+}
+
+$packages = Credits_Controller::get_credit_packages_config();
+?>
+<div <?php echo $wrapper_attributes; ?>>
+	<div class="wp-block-spawn-credit-purchase__header">
+		<span class="wp-block-spawn-credit-purchase__title">
+			<?php esc_html_e( 'Add Credits', 'spawn' ); ?>
+		</span>
+	</div>
+	<div class="wp-block-spawn-credit-purchase__options">
+		<?php foreach ( $packages as $key => $package ) : ?>
+			<button
+				class="wp-block-spawn-credit-purchase__option"
+				data-amount="<?php echo esc_attr( $package['price'] ); ?>"
+				type="button"
+			>
+				<span class="wp-block-spawn-credit-purchase__option-amount">$<?php echo esc_html( $package['price'] ); ?></span>
+				<span class="wp-block-spawn-credit-purchase__option-credits">
+					<?php echo esc_html( number_format( $package['credits'] ) ); ?> credits
+				</span>
+				<?php if ( ! empty( $package['bonus'] ) ) : ?>
+					<span class="wp-block-spawn-credit-purchase__option-bonus">
+						<?php echo esc_html( $package['bonus'] ); ?> bonus
+					</span>
+				<?php endif; ?>
+			</button>
+		<?php endforeach; ?>
+	</div>
+	<div class="wp-block-spawn-credit-purchase__loading" style="display: none;">
+		<span class="spinner"></span>
+		<?php esc_html_e( 'Redirecting to checkout...', 'spawn' ); ?>
+	</div>
+</div>

--- a/blocks/credit-purchase/style.css
+++ b/blocks/credit-purchase/style.css
@@ -1,0 +1,112 @@
+.wp-block-spawn-credit-purchase {
+	display: block;
+}
+
+.wp-block-spawn-credit-purchase__header {
+	margin-bottom: 12px;
+}
+
+.wp-block-spawn-credit-purchase__title {
+	font-size: 14px;
+	font-weight: 600;
+	color: #333;
+}
+
+.wp-block-spawn-credit-purchase__options {
+	display: grid;
+	grid-template-columns: repeat( 3, 1fr );
+	gap: 8px;
+}
+
+.wp-block-spawn-credit-purchase__option {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 4px;
+	padding: 12px 8px;
+	background: #fff;
+	border: 2px solid #e0e0e0;
+	border-radius: 8px;
+	cursor: pointer;
+	transition: all 0.2s ease;
+}
+
+.wp-block-spawn-credit-purchase__option:hover {
+	border-color: #2271b1;
+	background: #f0f6f9;
+}
+
+.wp-block-spawn-credit-purchase__option:active {
+	transform: scale( 0.98 );
+}
+
+.wp-block-spawn-credit-purchase__option-amount {
+	font-size: 18px;
+	font-weight: 700;
+	color: #2271b1;
+}
+
+.wp-block-spawn-credit-purchase__option-credits {
+	font-size: 11px;
+	color: #666;
+}
+
+.wp-block-spawn-credit-purchase__option-bonus {
+	font-size: 10px;
+	font-weight: 600;
+	color: #008a20;
+	background: #e8f5e9;
+	padding: 2px 6px;
+	border-radius: 4px;
+}
+
+.wp-block-spawn-credit-purchase__loading {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 8px;
+	padding: 16px;
+	color: #666;
+	font-size: 14px;
+}
+
+.wp-block-spawn-credit-purchase__loading .spinner {
+	float: none;
+	margin: 0;
+}
+
+.wp-block-spawn-credit-purchase__editor {
+	padding: 16px;
+	background: #f9f9f9;
+	border: 1px solid #ddd;
+	border-radius: 4px;
+}
+
+.wp-block-spawn-credit-purchase__editor-placeholder {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+}
+
+.wp-block-spawn-credit-purchase__editor-label {
+	font-size: 14px;
+	font-weight: 600;
+	color: #333;
+}
+
+.wp-block-spawn-credit-purchase__editor-buttons {
+	display: grid;
+	grid-template-columns: repeat( 3, 1fr );
+	gap: 8px;
+}
+
+.wp-block-spawn-credit-purchase__editor-btn {
+	padding: 12px 8px;
+	font-size: 16px;
+	font-weight: 600;
+	color: #2271b1;
+	background: #fff;
+	border: 2px solid #e0e0e0;
+	border-radius: 8px;
+	cursor: default;
+}

--- a/blocks/credit-purchase/view.js
+++ b/blocks/credit-purchase/view.js
@@ -1,0 +1,80 @@
+/**
+ * Credit Purchase block view script.
+ */
+( function () {
+	'use strict';
+
+	const API_ROOT = '/wp-json/spawn/v1';
+
+	async function purchaseCredits( amount, button ) {
+		const container = button.closest( '.wp-block-spawn-credit-purchase' );
+		if ( ! container ) {
+			return;
+		}
+
+		const options = container.querySelector( '.wp-block-spawn-credit-purchase__options' );
+		const loading = container.querySelector( '.wp-block-spawn-credit-purchase__loading' );
+
+		if ( ! options || ! loading ) {
+			return;
+		}
+
+		options.style.display = 'none';
+		loading.style.display = 'flex';
+
+		try {
+			const response = await fetch( `${ API_ROOT }/credits/purchase`, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+				},
+				body: JSON.stringify( { amount } ),
+				credentials: 'include',
+			} );
+
+			if ( ! response.ok ) {
+				const error = await response.json();
+				alert( error.message || 'Failed to create checkout session' );
+				options.style.display = 'grid';
+				loading.style.display = 'none';
+				return;
+			}
+
+			const data = await response.json();
+
+			if ( data.checkout_url ) {
+				window.location.href = data.checkout_url;
+			} else {
+				throw new Error( 'No checkout URL returned' );
+			}
+		} catch ( error ) {
+			console.error( 'Purchase failed:', error );
+			alert( 'Failed to process purchase. Please try again.' );
+			options.style.display = 'grid';
+			loading.style.display = 'none';
+		}
+	}
+
+	function init() {
+		const containers = document.querySelectorAll( '.wp-block-spawn-credit-purchase' );
+
+		containers.forEach( function ( container ) {
+			const options = container.querySelectorAll( '.wp-block-spawn-credit-purchase__option' );
+
+			options.forEach( function ( option ) {
+				option.addEventListener( 'click', function () {
+					const amount = parseInt( this.dataset.amount, 10 );
+					if ( amount >= 10 ) {
+						purchaseCredits( amount, this );
+					}
+				} );
+			} );
+		} );
+	}
+
+	if ( document.readyState === 'loading' ) {
+		document.addEventListener( 'DOMContentLoaded', init );
+	} else {
+		init();
+	}
+} )();

--- a/inc/class-blocks.php
+++ b/inc/class-blocks.php
@@ -31,6 +31,9 @@ class Blocks {
 			'account',
 			'chat',
 			'success',
+			'auth-gate',
+			'credit-balance',
+			'credit-purchase',
 		);
 
 		foreach ( $blocks as $block ) {


### PR DESCRIPTION
## What

Transforms the chat block into a composable block container with inner blocks for authentication, credit display, and purchasing. The chat block becomes a self-contained app — customers can authenticate, see their balance, and buy credits without leaving the page.

## New Blocks

### `spawn/auth-gate`
- Wraps inner content, shows login form when unauthenticated
- Uses WP native auth (wp_login_url, wp_registration_url, wp_lostpassword_url)
- Clean branded login with logo support via Branding class
- Renders children normally when authenticated

### `spawn/credit-balance`
- Displays current AI credit balance
- Server-rendered initial state, client-side polling (30s) for reactivity
- Shows \$0.00 with 'add credits' prompt when empty
- Uses `spawn/v1/credits/balance` REST endpoint

### `spawn/credit-purchase`
- Preset amount buttons (\$10, \$25, \$50)
- Redirects to Stripe hosted checkout via `spawn/v1/credits/purchase`
- Loading state while creating checkout session
- Returns to dashboard after successful purchase

## Chat Block Changes
- Added `allowedBlocks` for new inner blocks
- Added `providesContext` (`spawn/customerId`, `spawn/billingMode`, `spawn/isAuthenticated`)
- Server-side state injection via render.php
- InnerBlocks support in editor with default template

## WordPress-Native
- Gutenberg inner blocks for composable UI
- Block context for parent→child data flow
- Standard WP auth, no custom protocols
- Each block self-contained with render.php, index.js, view.js, style.css
- Registered via existing `class-blocks.php` pattern