### PR TITLE
Direct mode: chat block talks directly to customer gateway over HTTPS

### DIFF
--- a/blocks/chat/render.php
+++ b/blocks/chat/render.php
@@ -58,10 +58,20 @@ if ( $is_authenticated ) {
 	}
 }
 
-$login_url       = wp_login_url( get_permalink() );
+	$login_url       = wp_login_url( get_permalink() );
 $register_url    = wp_registration_url();
 $lost_password_url = wp_lostpassword_url( get_permalink() );
 $purchase_url    = rest_url( 'spawn/v1/credits/purchase' );
+
+$gateway_url  = '';
+$gateway_token = '';
+$chat_mode    = 'proxy';
+
+if ( ! empty( $customer['domain'] ) && 'active' === $customer['status'] ) {
+	$gateway_url  = 'https://' . $customer['domain'] . '/gateway';
+	$gateway_token = $customer['openclaw_token'] ?? '';
+	$chat_mode    = 'direct';
+}
 
 $spawn_state = array(
 	'isAuthenticated' => $is_authenticated,
@@ -79,6 +89,9 @@ $spawn_state = array(
 	'purchaseUrl'      => $purchase_url,
 	'brandName'        => $brand_name,
 	'brandLogoUrl'     => $brand_logo_url,
+	'gatewayUrl'       => $gateway_url,
+	'gatewayToken'     => $gateway_token,
+	'chatMode'         => $chat_mode,
 );
 ?>
 <div <?php echo $wrapper_attributes; ?> data-spawn-state="<?php echo esc_attr( wp_json_encode( $spawn_state ) ); ?>">

--- a/blocks/chat/view.ts
+++ b/blocks/chat/view.ts
@@ -25,6 +25,9 @@ interface SpawnState {
 	purchaseUrl: string;
 	brandName: string;
 	brandLogoUrl: string;
+	gatewayUrl: string;
+	gatewayToken: string;
+	chatMode: 'direct' | 'proxy';
 }
 
 interface ChatContext {
@@ -210,6 +213,9 @@ function initBlock( block: HTMLElement ): void {
 			purchaseUrl: '',
 			brandName: 'Spawn',
 			brandLogoUrl: '',
+			gatewayUrl: '',
+			gatewayToken: '',
+			chatMode: 'proxy',
 		};
 	}
 
@@ -591,8 +597,31 @@ function initBlock( block: HTMLElement ): void {
 		const savedKey = storage.getSessionKey();
 
 		try {
-			const response = await apiFetch< SessionsResponse | Session[] >( { path: API.sessions } );
-			const allSessions = ( response as SessionsResponse ).sessions || ( response as Session[] ) || [];
+			let allSessions: Session[] = [];
+
+			if ( spawnState.chatMode === 'direct' ) {
+				const response = await fetch( spawnState.gatewayUrl + '/tools/invoke', {
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json',
+						'Authorization': 'Bearer ' + spawnState.gatewayToken,
+					},
+					body: JSON.stringify( {
+						tool: 'sessions_list',
+						args: {},
+					} ),
+				} );
+
+				if ( response.ok ) {
+					const data = await response.json();
+					// Gateway /tools/invoke returns { ok, result: { content, details } }
+					const details = data.result?.details || data;
+					allSessions = details.sessions || [];
+				}
+			} else {
+				const response = await apiFetch< SessionsResponse | Session[] >( { path: API.sessions } );
+				allSessions = ( response as SessionsResponse ).sessions || ( response as Session[] ) || [];
+			}
 
 			sessions = allSessions
 				.filter( ( s ) => ( s.sessionKey || s.key || '' ).includes( 'webchat' ) )
@@ -629,8 +658,35 @@ function initBlock( block: HTMLElement ): void {
 		messagesContainer.innerHTML = '<div class="chat-message chat-message--system">Loading conversation...</div>';
 
 		try {
-			const response = await apiFetch< HistoryResponse | ChatMessage[] >( { path: API.history( key ) } );
-			const messages = ( response as HistoryResponse ).messages || ( response as ChatMessage[] ) || [];
+			let messages: ChatMessage[] = [];
+
+			if ( spawnState.chatMode === 'direct' ) {
+				const response = await fetch( spawnState.gatewayUrl + '/tools/invoke', {
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json',
+						'Authorization': 'Bearer ' + spawnState.gatewayToken,
+					},
+					body: JSON.stringify( {
+						tool: 'sessions_history',
+						args: {
+							sessionKey: key,
+							limit: 50,
+						},
+					} ),
+				} );
+
+				if ( response.ok ) {
+					const data = await response.json();
+					// Gateway /tools/invoke returns { ok, result: { content, details } }
+					const details = data.result?.details || data;
+					messages = details.messages || [];
+				}
+			} else {
+				const response = await apiFetch< HistoryResponse | ChatMessage[] >( { path: API.history( key ) } );
+				messages = ( response as HistoryResponse ).messages || ( response as ChatMessage[] ) || [];
+			}
+
 			renderHistory( messages );
 		} catch ( error ) {
 			console.error( 'Failed to load history:', error );
@@ -732,6 +788,14 @@ function initBlock( block: HTMLElement ): void {
 		const text = input.value.trim();
 		if ( ! text || isLoading ) return;
 
+		if ( spawnState.chatMode === 'direct' ) {
+			if ( spawnState.billingMode === 'managed' && spawnState.billingType !== 'comped' && currentBalance <= 0 ) {
+				currentState = 'credits-depleted';
+				renderState();
+				return;
+			}
+		}
+
 		if ( ! currentSessionKey ) {
 			currentSessionKey = generateSessionKey();
 			storage.setSessionKey( currentSessionKey );
@@ -748,7 +812,74 @@ function initBlock( block: HTMLElement ): void {
 		setLoading( true );
 
 		try {
-			const response = await apiFetch< ChatSendResponse >( {
+			let response: ChatSendResponse;
+
+			if ( spawnState.chatMode === 'direct' ) {
+				const headers: Record< string, string > = {
+					'Content-Type': 'application/json',
+					'Authorization': 'Bearer ' + spawnState.gatewayToken,
+				};
+
+				if ( currentSessionKey ) {
+					headers[ 'x-openclaw-session-key' ] = currentSessionKey;
+				}
+
+				const chatResponse = await fetch( spawnState.gatewayUrl + '/v1/chat/completions', {
+					method: 'POST',
+					headers,
+					body: JSON.stringify( {
+						model: 'openclaw:main',
+						messages: [
+							{
+								role: 'user',
+								content: text,
+							},
+						],
+					} ),
+				} );
+
+				if ( chatResponse.status === 402 || chatResponse.status === 403 ) {
+					currentState = 'credits-depleted';
+					await fetchBalance();
+					renderState();
+					setLoading( false );
+					return;
+				}
+
+				if ( ! chatResponse.ok ) {
+					const errorData = await chatResponse.json().catch( () => ( {} ) );
+					if ( chatResponse.status === 0 ) {
+						addMessage( 'system', 'Your agent is offline. It may be restarting.' );
+					} else {
+						addMessage( 'system', `Error: ${ errorData.error?.message || 'Failed to get response' }` );
+					}
+					setLoading( false );
+					input.focus();
+					return;
+				}
+
+				const chatData = await chatResponse.json();
+				const reply = chatData.choices?.[ 0 ]?.message?.content;
+
+				if ( reply ) {
+					addMessage( 'assistant', reply );
+					await fetchBalance();
+
+					if ( currentBalance <= 0 && spawnState.billingMode === 'managed' ) {
+						currentState = 'credits-depleted';
+						renderState();
+					}
+				} else {
+					addMessage( 'system', 'No response received from agent.' );
+				}
+
+				loadSessions();
+				setLoading( false );
+				input.focus();
+				return;
+			}
+
+			response = await apiFetch< ChatSendResponse >( {
 				path: API.send,
 				method: 'POST',
 				data: { message: text, sessionKey: currentSessionKey, context },

--- a/inc/controllers/class-chat-controller.php
+++ b/inc/controllers/class-chat-controller.php
@@ -2,6 +2,14 @@
 /**
  * Chat REST API Controller.
  *
+ * NOTE: This controller is only used for proxy mode:
+ * - Admin chat (control plane OpenClaw)
+ * - Self-spawn mode (local OpenClaw on the same server)
+ *
+ * Customer chat now uses direct mode: the browser talks directly to the
+ * customer's VPS gateway over HTTPS. See blocks/chat/view.ts for the
+ * client-side direct mode implementation.
+ *
  * Handles chat sessions, messages, and history.
  *
  * @package Spawn


### PR DESCRIPTION
## What

Customer chat now bypasses our server entirely. The chat block talks directly to the customer's OpenClaw gateway over HTTPS. Our server never sees the conversation.

## Architecture

```
Before: Browser → our server (proxy) → customer VPS (plain HTTP)
After:  Browser → customer VPS directly (HTTPS via nginx gateway proxy)
```

## How It Works

**render.php** injects `chatMode`, `gatewayUrl`, and `gatewayToken` into the block state:
- Active customer with a domain → `chatMode: 'direct'`, `gatewayUrl: 'https://their-domain.com/gateway'`
- Admin / self-spawn / no domain → `chatMode: 'proxy'` (existing behavior)

**view.ts** checks the mode and routes accordingly:
- **Direct mode**: `fetch(gatewayUrl + '/v1/chat/completions', ...)` with Authorization header
- **Proxy mode**: existing `apiFetch({ path: 'spawn/v1/chat/send' })` 
- Sessions and history also go direct via `/tools/invoke` endpoint
- Credit balance still fetched from our billing API after each message

## What Still Uses Proxy

- Admin chat (control plane OpenClaw)
- Self-spawn mode (local OpenClaw)
- These are intentional — admin talks to our infrastructure, not a customer VPS

## Security

- TLS required (HTTPS only, no HTTP fallback)
- Gateway token in Authorization header (never in URL)
- CORS on customer VPS allows Spawn storefront origin only
- Our server only handles billing — never sees conversation content
- Credit balance checked client-side before send (managed mode)

## Build
`npm run build` ✅ — compiles successfully