### PR TITLE
Remove BYOK and proxy mode dead code from chat block

### DIFF
--- a/blocks/chat/render.php
+++ b/blocks/chat/render.php
@@ -26,7 +26,6 @@ $is_authenticated = is_user_logged_in();
 $is_admin         = current_user_can( 'manage_options' );
 $customer_id      = 0;
 $credit_balance   = 0.0;
-$billing_mode     = 'managed';
 $billing_type     = 'paid';
 $username         = '';
 $domain           = '';
@@ -43,14 +42,12 @@ if ( $is_authenticated ) {
 	if ( $customer ) {
 		$customer_id     = (int) $customer['id'];
 		$credit_balance  = (float) $customer['credit_balance'];
-		$billing_mode     = $customer['billing_mode'] ?? 'managed';
 		$billing_type     = $customer['billing_type'] ?? 'paid';
 		$domain           = $customer['domain'] ?? '';
 		$status           = $customer['status'] ?? '';
 		$server_ready     = ! empty( $customer['server_ip'] ) && 'provisioning' !== $customer['status'];
 	} elseif ( $is_admin ) {
 		$customer_id   = 0;
-		$billing_mode   = 'managed';
 		$billing_type   = 'comped';
 		$domain         = Branding::get_subdomain_suffix();
 		$status         = 'admin';
@@ -65,19 +62,16 @@ $purchase_url    = rest_url( 'spawn/v1/credits/purchase' );
 
 $gateway_url  = '';
 $gateway_token = '';
-$chat_mode    = 'proxy';
 
 if ( ! empty( $customer['domain'] ) && 'active' === $customer['status'] ) {
 	$gateway_url  = 'https://' . $customer['domain'] . '/gateway';
 	$gateway_token = $customer['openclaw_token'] ?? '';
-	$chat_mode    = 'direct';
 }
 
 $spawn_state = array(
 	'isAuthenticated' => $is_authenticated,
 	'customerId'      => $customer_id,
 	'creditBalance'   => $credit_balance,
-	'billingMode'      => $billing_mode,
 	'billingType'      => $billing_type,
 	'username'         => $username,
 	'domain'           => $domain,
@@ -91,7 +85,6 @@ $spawn_state = array(
 	'brandLogoUrl'     => $brand_logo_url,
 	'gatewayUrl'       => $gateway_url,
 	'gatewayToken'     => $gateway_token,
-	'chatMode'         => $chat_mode,
 );
 ?>
 <div <?php echo $wrapper_attributes; ?> data-spawn-state="<?php echo esc_attr( wp_json_encode( $spawn_state ) ); ?>">

--- a/blocks/chat/view.ts
+++ b/blocks/chat/view.ts
@@ -13,7 +13,6 @@ interface SpawnState {
 	isAuthenticated: boolean;
 	customerId: number;
 	creditBalance: number;
-	billingMode: 'managed' | 'byok';
 	billingType: 'paid' | 'comped';
 	username: string;
 	domain: string;
@@ -27,7 +26,6 @@ interface SpawnState {
 	brandLogoUrl: string;
 	gatewayUrl: string;
 	gatewayToken: string;
-	chatMode: 'direct' | 'proxy';
 }
 
 interface ChatContext {
@@ -90,9 +88,6 @@ interface SessionTitles {
 }
 
 const API = {
-	send: '/spawn/v1/chat/send',
-	sessions: '/spawn/v1/chat/sessions',
-	history: ( key: string ) => `/spawn/v1/chat/sessions/${ key }/history?limit=50`,
 	generateTitle: '/spawn/v1/chat/generate-title',
 	balance: '/spawn/v1/credits/balance',
 	purchase: '/spawn/v1/credits/purchase',
@@ -201,7 +196,6 @@ function initBlock( block: HTMLElement ): void {
 			isAuthenticated: false,
 			customerId: 0,
 			creditBalance: 0,
-			billingMode: 'managed',
 			billingType: 'paid',
 			username: '',
 			domain: '',
@@ -215,7 +209,6 @@ function initBlock( block: HTMLElement ): void {
 			brandLogoUrl: '',
 			gatewayUrl: '',
 			gatewayToken: '',
-			chatMode: 'proxy',
 		};
 	}
 
@@ -239,7 +232,7 @@ function initBlock( block: HTMLElement ): void {
 		if ( ! state.serverReady ) {
 			return 'provisioning';
 		}
-		if ( state.billingMode === 'byok' || state.billingType === 'comped' || state.customerId === 0 ) {
+		if ( state.billingType === 'comped' || state.customerId === 0 ) {
 			return 'chat';
 		}
 		if ( state.creditBalance <= 0 ) {
@@ -599,28 +592,23 @@ function initBlock( block: HTMLElement ): void {
 		try {
 			let allSessions: Session[] = [];
 
-			if ( spawnState.chatMode === 'direct' ) {
-				const response = await fetch( spawnState.gatewayUrl + '/tools/invoke', {
-					method: 'POST',
-					headers: {
-						'Content-Type': 'application/json',
-						'Authorization': 'Bearer ' + spawnState.gatewayToken,
-					},
-					body: JSON.stringify( {
-						tool: 'sessions_list',
-						args: {},
-					} ),
-				} );
+			const response = await fetch( spawnState.gatewayUrl + '/tools/invoke', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					'Authorization': 'Bearer ' + spawnState.gatewayToken,
+				},
+				body: JSON.stringify( {
+					tool: 'sessions_list',
+					args: {},
+				} ),
+			} );
 
-				if ( response.ok ) {
-					const data = await response.json();
-					// Gateway /tools/invoke returns { ok, result: { content, details } }
-					const details = data.result?.details || data;
-					allSessions = details.sessions || [];
-				}
-			} else {
-				const response = await apiFetch< SessionsResponse | Session[] >( { path: API.sessions } );
-				allSessions = ( response as SessionsResponse ).sessions || ( response as Session[] ) || [];
+			if ( response.ok ) {
+				const data = await response.json();
+				// Gateway /tools/invoke returns { ok, result: { content, details } }
+				const details = data.result?.details || data;
+				allSessions = details.sessions || [];
 			}
 
 			sessions = allSessions
@@ -660,31 +648,26 @@ function initBlock( block: HTMLElement ): void {
 		try {
 			let messages: ChatMessage[] = [];
 
-			if ( spawnState.chatMode === 'direct' ) {
-				const response = await fetch( spawnState.gatewayUrl + '/tools/invoke', {
-					method: 'POST',
-					headers: {
-						'Content-Type': 'application/json',
-						'Authorization': 'Bearer ' + spawnState.gatewayToken,
+			const response = await fetch( spawnState.gatewayUrl + '/tools/invoke', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					'Authorization': 'Bearer ' + spawnState.gatewayToken,
+				},
+				body: JSON.stringify( {
+					tool: 'sessions_history',
+					args: {
+						sessionKey: key,
+						limit: 50,
 					},
-					body: JSON.stringify( {
-						tool: 'sessions_history',
-						args: {
-							sessionKey: key,
-							limit: 50,
-						},
-					} ),
-				} );
+				} ),
+			} );
 
-				if ( response.ok ) {
-					const data = await response.json();
-					// Gateway /tools/invoke returns { ok, result: { content, details } }
-					const details = data.result?.details || data;
-					messages = details.messages || [];
-				}
-			} else {
-				const response = await apiFetch< HistoryResponse | ChatMessage[] >( { path: API.history( key ) } );
-				messages = ( response as HistoryResponse ).messages || ( response as ChatMessage[] ) || [];
+			if ( response.ok ) {
+				const data = await response.json();
+				// Gateway /tools/invoke returns { ok, result: { content, details } }
+				const details = data.result?.details || data;
+				messages = details.messages || [];
 			}
 
 			renderHistory( messages );
@@ -788,12 +771,10 @@ function initBlock( block: HTMLElement ): void {
 		const text = input.value.trim();
 		if ( ! text || isLoading ) return;
 
-		if ( spawnState.chatMode === 'direct' ) {
-			if ( spawnState.billingMode === 'managed' && spawnState.billingType !== 'comped' && currentBalance <= 0 ) {
-				currentState = 'credits-depleted';
-				renderState();
-				return;
-			}
+		if ( spawnState.billingType !== 'comped' && currentBalance <= 0 ) {
+			currentState = 'credits-depleted';
+			renderState();
+			return;
 		}
 
 		if ( ! currentSessionKey ) {
@@ -814,78 +795,30 @@ function initBlock( block: HTMLElement ): void {
 		try {
 			let response: ChatSendResponse;
 
-			if ( spawnState.chatMode === 'direct' ) {
-				const headers: Record< string, string > = {
-					'Content-Type': 'application/json',
-					'Authorization': 'Bearer ' + spawnState.gatewayToken,
-				};
+			const headers: Record< string, string > = {
+				'Content-Type': 'application/json',
+				'Authorization': 'Bearer ' + spawnState.gatewayToken,
+			};
 
-				if ( currentSessionKey ) {
-					headers[ 'x-openclaw-session-key' ] = currentSessionKey;
-				}
-
-				const chatResponse = await fetch( spawnState.gatewayUrl + '/v1/chat/completions', {
-					method: 'POST',
-					headers,
-					body: JSON.stringify( {
-						model: 'openclaw:main',
-						messages: [
-							{
-								role: 'user',
-								content: text,
-							},
-						],
-					} ),
-				} );
-
-				if ( chatResponse.status === 402 || chatResponse.status === 403 ) {
-					currentState = 'credits-depleted';
-					await fetchBalance();
-					renderState();
-					setLoading( false );
-					return;
-				}
-
-				if ( ! chatResponse.ok ) {
-					const errorData = await chatResponse.json().catch( () => ( {} ) );
-					if ( chatResponse.status === 0 ) {
-						addMessage( 'system', 'Your agent is offline. It may be restarting.' );
-					} else {
-						addMessage( 'system', `Error: ${ errorData.error?.message || 'Failed to get response' }` );
-					}
-					setLoading( false );
-					input.focus();
-					return;
-				}
-
-				const chatData = await chatResponse.json();
-				const reply = chatData.choices?.[ 0 ]?.message?.content;
-
-				if ( reply ) {
-					addMessage( 'assistant', reply );
-					await fetchBalance();
-
-					if ( currentBalance <= 0 && spawnState.billingMode === 'managed' ) {
-						currentState = 'credits-depleted';
-						renderState();
-					}
-				} else {
-					addMessage( 'system', 'No response received from agent.' );
-				}
-
-				loadSessions();
-				setLoading( false );
-				input.focus();
-				return;
+			if ( currentSessionKey ) {
+				headers[ 'x-openclaw-session-key' ] = currentSessionKey;
 			}
 
-			response = await apiFetch< ChatSendResponse >( {
-				path: API.send,
+			const chatResponse = await fetch( spawnState.gatewayUrl + '/v1/chat/completions', {
 				method: 'POST',
-				data: { message: text, sessionKey: currentSessionKey, context },
+				headers,
+				body: JSON.stringify( {
+					model: 'openclaw:main',
+					messages: [
+						{
+							role: 'user',
+							content: text,
+						},
+					],
+				} ),
 			} );
 
-			if ( response.code === 'insufficient_credits' || ( response.error && ( response.error.toLowerCase().includes( 'credit' ) || response.error.toLowerCase().includes( 'insufficient' ) ) ) ) {
+			if ( chatResponse.status === 402 || chatResponse.status === 403 ) {
 				currentState = 'credits-depleted';
 				await fetchBalance();
 				renderState();
@@ -893,11 +826,31 @@ function initBlock( block: HTMLElement ): void {
 				return;
 			}
 
-			if ( response.reply ) {
-				addMessage( 'assistant', response.reply );
+			if ( ! chatResponse.ok ) {
+				const errorData = await chatResponse.json().catch( () => ( {} ) );
+				if ( chatResponse.status === 0 ) {
+					addMessage( 'system', 'Your agent is offline. It may be restarting.' );
+				} else {
+					addMessage( 'system', `Error: ${ errorData.error?.message || 'Failed to get response' }` );
+				}
+				setLoading( false );
+				input.focus();
+				return;
+			}
+
+			const chatData = await chatResponse.json();
+			const reply = chatData.choices?.[ 0 ]?.message?.content;
+
+			if ( reply ) {
+				addMessage( 'assistant', reply );
 				await fetchBalance();
-			} else if ( response.error ) {
-				addMessage( 'system', `Error: ${ response.error }` );
+
+				if ( currentBalance <= 0 && spawnState.billingType !== 'comped' ) {
+					currentState = 'credits-depleted';
+					renderState();
+				}
+			} else {
+				addMessage( 'system', 'No response received from agent.' );
 			}
 
 			loadSessions();


### PR DESCRIPTION
Removes dead BYOK billing mode and proxy chat mode references from the chat block.

**view.ts:**
- Removed `billingMode` and `chatMode` from SpawnState interface
- Removed proxy mode code paths (apiFetch calls) — direct mode only
- Cleaned up dead API endpoints (send, sessions, history)
- Simplified credit check logic to `billingType !== 'comped'`

**render.php:**
- Removed `$billing_mode` and `$chat_mode` variables
- Removed both fields from spawn_state array

2 files changed, 81 insertions(+), 135 deletions(-)